### PR TITLE
Migrate codebase to required keyword and collection literals

### DIFF
--- a/lib/aplication_localization.dart
+++ b/lib/aplication_localization.dart
@@ -56,7 +56,7 @@ class _AppLocalizationsDelegate
   @override
   Future<AppLocalizations> load(Locale locale) async {
     // AppLocalizations class is where the JSON loading actually runs
-    AppLocalizations localizations = new AppLocalizations(locale);
+    AppLocalizations localizations = AppLocalizations(locale);
     await localizations.load();
     return localizations;
   }

--- a/lib/app/dio/dio.dart
+++ b/lib/app/dio/dio.dart
@@ -9,7 +9,7 @@ class GetDio {
   GetDio._();
 
   static Dio getDio() {
-    Dio dio = new Dio();
+    Dio dio = Dio();
     dio.interceptors.add(
       InterceptorsWrapper(
         onRequest: (RequestOptions options) async {

--- a/lib/bloc/feed/news_feed_bloc.dart
+++ b/lib/bloc/feed/news_feed_bloc.dart
@@ -11,8 +11,8 @@ import 'package:inshort_clone/model/news_model.dart';
 import 'package:inshort_clone/services/news/news_service.dart';
 
 class NewsFeedBloc extends Bloc<NewsFeedEvent, NewsFeedState> {
-  NewsFeedRepository repository;
-  NewsFeedBloc({@required this.repository});
+  final NewsFeedRepository repository;
+  NewsFeedBloc({required this.repository});
 
   @override
   NewsFeedState get initialState => NewsFeedInitialState();

--- a/lib/bloc/feed/news_feed_event.dart
+++ b/lib/bloc/feed/news_feed_event.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 // Package imports:
 import 'package:equatable/equatable.dart';
@@ -8,21 +8,27 @@ abstract class NewsFeedEvent extends Equatable {}
 
 class FetchNewsByCategoryEvent extends NewsFeedEvent {
   final String category;
-  FetchNewsByCategoryEvent({@required this.category});
 
-  List<Object> get props => [category];
+  FetchNewsByCategoryEvent({required this.category});
+
+  @override
+  List<Object?> get props => [category];
 }
 
 class FetchNewsByTopicEvent extends NewsFeedEvent {
   final String topic;
-  FetchNewsByTopicEvent({@required this.topic});
 
-  List<Object> get props => [topic];
+  FetchNewsByTopicEvent({required this.topic});
+
+  @override
+  List<Object?> get props => [topic];
 }
 
 class FetchNewsFromLocalStorageEvent extends NewsFeedEvent {
   final String box;
-  FetchNewsFromLocalStorageEvent({@required this.box});
 
-  List<Object> get props => [box];
+  FetchNewsFromLocalStorageEvent({required this.box});
+
+  @override
+  List<Object?> get props => [box];
 }

--- a/lib/bloc/feed/news_feed_state.dart
+++ b/lib/bloc/feed/news_feed_state.dart
@@ -9,26 +9,29 @@ abstract class NewsFeedState extends Equatable {}
 
 class NewsFeedInitialState extends NewsFeedState {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class NewsFeedLoadingState extends NewsFeedState {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class NewsFeedLoadedState extends NewsFeedState {
   final List<Articles> news;
-  NewsFeedLoadedState({@required this.news});
+
+  NewsFeedLoadedState({required this.news});
   get moviesList => news;
 
   @override
-  List<Object> get props => null;
+  List<Object?> get props => [news];
 }
 
 class NewsFeedErrorState extends NewsFeedState {
   final String message;
-  NewsFeedErrorState({@required this.message});
+
+  NewsFeedErrorState({required this.message});
+
   @override
-  List<Object> get props => null;
+  List<Object?> get props => [message];
 }

--- a/lib/bloc/serach_feed/search_feed_bloc.dart
+++ b/lib/bloc/serach_feed/search_feed_bloc.dart
@@ -11,8 +11,8 @@ import 'search_feed_event.dart';
 import 'search_feed_state.dart';
 
 class SearchFeedBloc extends Bloc<SearchFeedEvent, SearchFeedState> {
-  NewsFeedRepository repository;
-  SearchFeedBloc({@required this.repository});
+  final NewsFeedRepository repository;
+  SearchFeedBloc({required this.repository});
 
   @override
   SearchFeedState get initialState => SearchFeedInitialState();

--- a/lib/bloc/serach_feed/search_feed_event.dart
+++ b/lib/bloc/serach_feed/search_feed_event.dart
@@ -1,5 +1,5 @@
 // Flutter imports:
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 
 // Package imports:
 import 'package:equatable/equatable.dart';
@@ -8,7 +8,9 @@ abstract class SearchFeedEvent extends Equatable {}
 
 class FetchNewsBySearchQueryEvent extends SearchFeedEvent {
   final String query;
-  FetchNewsBySearchQueryEvent({@required this.query});
 
-  List<Object> get props => [query];
+  FetchNewsBySearchQueryEvent({required this.query});
+
+  @override
+  List<Object?> get props => [query];
 }

--- a/lib/bloc/serach_feed/search_feed_state.dart
+++ b/lib/bloc/serach_feed/search_feed_state.dart
@@ -9,26 +9,29 @@ abstract class SearchFeedState extends Equatable {}
 
 class SearchFeedInitialState extends SearchFeedState {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class SearchFeedLoadingState extends SearchFeedState {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class SearchFeedLoadedState extends SearchFeedState {
   final List<Articles> news;
-  SearchFeedLoadedState({@required this.news});
+
+  SearchFeedLoadedState({required this.news});
   get moviesList => news;
 
   @override
-  List<Object> get props => null;
+  List<Object?> get props => [news];
 }
 
 class SearchFeedErrorState extends SearchFeedState {
   final String message;
-  SearchFeedErrorState({@required this.message});
+
+  SearchFeedErrorState({required this.message});
+
   @override
-  List<Object> get props => null;
+  List<Object?> get props => [message];
 }

--- a/lib/common/widgets/news_card/bottom_action_bar.dart
+++ b/lib/common/widgets/news_card/bottom_action_bar.dart
@@ -65,9 +65,9 @@ class BottomActionBar extends StatelessWidget {
   }
 
   Widget actionButton({
-    @required String title,
-    @required IconData icon,
-    @required Function onTap,
+    required String title,
+    required IconData icon,
+    required Function onTap,
   }) {
     return InkWell(
       onTap: onTap,

--- a/lib/model/news_model.dart
+++ b/lib/model/news_model.dart
@@ -14,15 +14,15 @@ class NewsModel {
     status = json['status'];
     totalResults = json['totalResults'];
     if (json['articles'] != null) {
-      articles = new List<Articles>();
+      articles = <Articles>[];
       json['articles'].forEach((v) {
-        articles.add(new Articles.fromJson(v));
+        articles.add(Articles.fromJson(v));
       });
     }
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
+    final Map<String, dynamic> data = <String, dynamic>{};
     data['status'] = this.status;
     data['totalResults'] = this.totalResults;
     if (this.articles != null) {
@@ -63,7 +63,7 @@ class Articles {
 
   Articles.fromJson(Map<String, dynamic> json) {
     sourceName = json['source'] != null
-        ? new Source.fromJson(json['source']).name
+        ? Source.fromJson(json['source']).name
         : null;
     author = json['author'];
     title = json['title'];
@@ -75,7 +75,7 @@ class Articles {
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
+    final Map<String, dynamic> data = <String, dynamic>{};
     if (this.sourceName != null) {
       data['sourceName'] = this.sourceName;
     }
@@ -102,7 +102,7 @@ class Source {
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
+    final Map<String, dynamic> data = <String, dynamic>{};
     data['id'] = this.id;
     data['name'] = this.name;
     return data;

--- a/lib/routes/rouut.dart
+++ b/lib/routes/rouut.dart
@@ -113,17 +113,18 @@ class FeedScreenArguments {
   final int articalIndex;
   final List<Articles> articals;
   final bool isFromSearch;
-  FeedScreenArguments(
-      {this.key,
-      @required this.articalIndex,
-      @required this.articals,
-      @required this.isFromSearch});
+  FeedScreenArguments({
+    this.key,
+    required this.articalIndex,
+    required this.articals,
+    required this.isFromSearch,
+  });
 }
 
 class ExpandedImageViewArguments {
   final String image;
   ExpandedImageViewArguments({
-    @required this.image,
+    required this.image,
   });
 }
 
@@ -131,5 +132,5 @@ class WebViewArguments {
   final String url;
   final bool isFromBottom;
 
-  WebViewArguments({@required this.url, @required this.isFromBottom});
+  WebViewArguments({required this.url, required this.isFromBottom});
 }

--- a/lib/view/feed_screen/feed.dart
+++ b/lib/view/feed_screen/feed.dart
@@ -16,12 +16,12 @@ class FeedScreen extends StatefulWidget {
   final int articalIndex;
   final bool isFromSearch;
 
-  const FeedScreen(
-      {Key key,
-      @required this.articalIndex,
-      @required this.articals,
-      @required this.isFromSearch})
-      : super(key: key);
+  const FeedScreen({
+    Key? key,
+    required this.articalIndex,
+    required this.articals,
+    required this.isFromSearch,
+  }) : super(key: key);
 
   @override
   _FeedScreenState createState() => _FeedScreenState();

--- a/lib/view/photo_view/photo_expanded_screen.dart
+++ b/lib/view/photo_view/photo_expanded_screen.dart
@@ -8,7 +8,7 @@ import 'package:photo_view/photo_view.dart';
 class ExpandedImageView extends StatelessWidget {
   final image;
 
-  ExpandedImageView({@required this.image});
+  const ExpandedImageView({required this.image});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/view/settings_screen/settings.dart
+++ b/lib/view/settings_screen/settings.dart
@@ -56,9 +56,9 @@ class SettingsScreen extends StatelessWidget {
                   underline: Container(),
                   value: settingsProvider.activeLanguge,
                   items: Global.lang.map((String value) {
-                    return new DropdownMenuItem<String>(
+                    return DropdownMenuItem<String>(
                       value: value,
-                      child: new Text(value),
+                      child: Text(value),
                     );
                   }).toList(),
                   onChanged: (v) {

--- a/lib/view/web_screen/web.dart
+++ b/lib/view/web_screen/web.dart
@@ -18,8 +18,11 @@ class WebScreen extends StatefulWidget {
   final bool isFromBottom;
   final PageController pageController;
 
-  WebScreen(
-      {@required this.url, @required this.isFromBottom, this.pageController});
+  const WebScreen({
+    required this.url,
+    required this.isFromBottom,
+    this.pageController,
+  });
 
   @override
   _WebScreenState createState() => _WebScreenState();


### PR DESCRIPTION
## Summary
- use `required` keyword instead of deprecated `@required`
- replace `new` keywords with collection literals
- ensure all Equatable `props` lists are non-null

## Testing
- `dart migrate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa6f4cd8c8329959e015a2fbbadc1