### PR TITLE
Fix Equatable props in BLoC states

### DIFF
--- a/lib/bloc/feed/news_feed_state.dart
+++ b/lib/bloc/feed/news_feed_state.dart
@@ -9,26 +9,24 @@ abstract class NewsFeedState extends Equatable {}
 
 class NewsFeedInitialState extends NewsFeedState {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class NewsFeedLoadingState extends NewsFeedState {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class NewsFeedLoadedState extends NewsFeedState {
   final List<Articles> news;
   NewsFeedLoadedState({@required this.news});
-  get moviesList => news;
-
   @override
-  List<Object> get props => null;
+  List<Object?> get props => [news];
 }
 
 class NewsFeedErrorState extends NewsFeedState {
   final String message;
   NewsFeedErrorState({@required this.message});
   @override
-  List<Object> get props => null;
+  List<Object?> get props => [message];
 }

--- a/lib/bloc/serach_feed/search_feed_state.dart
+++ b/lib/bloc/serach_feed/search_feed_state.dart
@@ -9,26 +9,24 @@ abstract class SearchFeedState extends Equatable {}
 
 class SearchFeedInitialState extends SearchFeedState {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class SearchFeedLoadingState extends SearchFeedState {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 class SearchFeedLoadedState extends SearchFeedState {
   final List<Articles> news;
   SearchFeedLoadedState({@required this.news});
-  get moviesList => news;
-
   @override
-  List<Object> get props => null;
+  List<Object?> get props => [news];
 }
 
 class SearchFeedErrorState extends SearchFeedState {
   final String message;
   SearchFeedErrorState({@required this.message});
   @override
-  List<Object> get props => null;
+  List<Object?> get props => [message];
 }


### PR DESCRIPTION
## Summary
- ensure BLoC state equality checks include their properties
- remove unused getters

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa90531cc83299d4f5b2c7c4eb841