### PR TITLE
Replace esys_flutter_share usage with share_plus

### DIFF
--- a/lib/services/news/share_service.dart
+++ b/lib/services/news/share_service.dart
@@ -8,23 +8,34 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
 // Package imports:
-import 'package:esys_flutter_share/esys_flutter_share.dart';
+import 'dart:io';
+
+import 'package:share_plus/share_plus.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 
 // Project imports:
 import 'package:inshort_clone/controller/provider.dart';
 
 void convertWidgetToImageAndShare(BuildContext context, containerKey) async {
-  RenderRepaintBoundary renderRepaintBoundary =
-      containerKey.currentContext.findRenderObject();
-  ui.Image boxImage = await renderRepaintBoundary.toImage(pixelRatio: 1);
-  ByteData byteData = await boxImage.toByteData(format: ui.ImageByteFormat.png);
-  Uint8List uInt8List = byteData.buffer.asUint8List();
+  final RenderRepaintBoundary renderRepaintBoundary =
+      containerKey.currentContext.findRenderObject() as RenderRepaintBoundary;
+  final ui.Image boxImage =
+      await renderRepaintBoundary.toImage(pixelRatio: 1);
+  final ByteData byteData =
+      await boxImage.toByteData(format: ui.ImageByteFormat.png);
+  final Uint8List uInt8List = byteData.buffer.asUint8List();
+
   try {
-    await Share.file(
-        'imsanjaysoni/InshortClone', 'inshortClone.png', uInt8List, 'image/png',
-        text:
-            'This message sent from *inshorts Clone* made by *Sanjay Soni*\nFork this repository on *Github*\n\n https://github.com/imSanjaySoni/Inshorts-Clone.');
+    final tempDir = await getTemporaryDirectory();
+    final file = await File('${tempDir.path}/inshortClone.png').create();
+    await file.writeAsBytes(uInt8List);
+
+    await Share.shareXFiles([
+      XFile(file.path,
+          mimeType: 'image/png',
+          name: 'inshortClone.png'),
+    ], text: 'This message sent from *inshorts Clone* made by *Sanjay Soni*\nFork this repository on *Github*\n\n https://github.com/imSanjaySoni/Inshorts-Clone.');
   } catch (e) {
     print('error: $e');
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,13 +225,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
-  esys_flutter_share:
-    dependency: "direct main"
-    description:
-      name: esys_flutter_share
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- remove old `esys_flutter_share` dependency from lockfile
- use `share_plus` for sharing screenshots

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685facd546ac8329a5c421580febe285