### PR TITLE
Refactor blocs to use new Bloc API

### DIFF
--- a/lib/bloc/feed/news_feed_bloc.dart
+++ b/lib/bloc/feed/news_feed_bloc.dart
@@ -12,38 +12,43 @@ import 'package:inshort_clone/services/news/news_service.dart';
 
 class NewsFeedBloc extends Bloc<NewsFeedEvent, NewsFeedState> {
   final NewsFeedRepository repository;
-  NewsFeedBloc({required this.repository});
+  NewsFeedBloc({required this.repository}) : super(NewsFeedInitialState()) {
+    on<FetchNewsByCategoryEvent>(_onFetchNewsByCategory);
+    on<FetchNewsByTopicEvent>(_onFetchNewsByTopic);
+    on<FetchNewsFromLocalStorageEvent>(_onFetchNewsFromLocalStorage);
+  }
 
-  @override
-  NewsFeedState get initialState => NewsFeedInitialState();
+  Future<void> _onFetchNewsByCategory(
+      FetchNewsByCategoryEvent event, Emitter<NewsFeedState> emit) async {
+    emit(NewsFeedLoadingState());
+    try {
+      final List<Articles> news =
+          await repository.getNewsByCategory(event.category);
+      emit(NewsFeedLoadedState(news: news));
+    } catch (e) {
+      emit(NewsFeedErrorState(message: e.toString()));
+    }
+  }
 
-  @override
-  Stream<NewsFeedState> mapEventToState(NewsFeedEvent event) async* {
-    if (event is FetchNewsByCategoryEvent) {
-      yield NewsFeedLoadingState();
-      try {
-        List<Articles> news =
-            await repository.getNewsByCategory(event.category);
-        yield NewsFeedLoadedState(news: news);
-      } catch (e) {
-        yield NewsFeedErrorState(message: e.toString());
-      }
-    } else if (event is FetchNewsByTopicEvent) {
-      yield NewsFeedLoadingState();
-      try {
-        List<Articles> news = await repository.getNewsByTopic(event.topic);
-        yield NewsFeedLoadedState(news: news);
-      } catch (e) {
-        yield NewsFeedErrorState(message: e.toString());
-      }
-    } else if (event is FetchNewsFromLocalStorageEvent) {
-      yield NewsFeedLoadingState();
-      try {
-        List<Articles> news = repository.getNewsFromLocalStorage(event.box);
-        yield NewsFeedLoadedState(news: news);
-      } catch (e) {
-        yield NewsFeedErrorState(message: e.toString());
-      }
+  Future<void> _onFetchNewsByTopic(
+      FetchNewsByTopicEvent event, Emitter<NewsFeedState> emit) async {
+    emit(NewsFeedLoadingState());
+    try {
+      final List<Articles> news = await repository.getNewsByTopic(event.topic);
+      emit(NewsFeedLoadedState(news: news));
+    } catch (e) {
+      emit(NewsFeedErrorState(message: e.toString()));
+    }
+  }
+
+  Future<void> _onFetchNewsFromLocalStorage(
+      FetchNewsFromLocalStorageEvent event, Emitter<NewsFeedState> emit) async {
+    emit(NewsFeedLoadingState());
+    try {
+      final List<Articles> news = repository.getNewsFromLocalStorage(event.box);
+      emit(NewsFeedLoadedState(news: news));
+    } catch (e) {
+      emit(NewsFeedErrorState(message: e.toString()));
     }
   }
 }

--- a/lib/bloc/serach_feed/search_feed_bloc.dart
+++ b/lib/bloc/serach_feed/search_feed_bloc.dart
@@ -12,22 +12,19 @@ import 'search_feed_state.dart';
 
 class SearchFeedBloc extends Bloc<SearchFeedEvent, SearchFeedState> {
   final NewsFeedRepository repository;
-  SearchFeedBloc({required this.repository});
+  SearchFeedBloc({required this.repository}) : super(SearchFeedInitialState()) {
+    on<FetchNewsBySearchQueryEvent>(_onFetchNewsBySearchQuery);
+  }
 
-  @override
-  SearchFeedState get initialState => SearchFeedInitialState();
-
-  @override
-  Stream<SearchFeedState> mapEventToState(SearchFeedEvent event) async* {
-    if (event is FetchNewsBySearchQueryEvent) {
-      yield SearchFeedLoadingState();
-      try {
-        List<Articles> news =
-            await repository.getNewsBySearchQuery(event.query);
-        yield SearchFeedLoadedState(news: news);
-      } catch (e) {
-        yield SearchFeedErrorState(message: e.toString());
-      }
+  Future<void> _onFetchNewsBySearchQuery(
+      FetchNewsBySearchQueryEvent event, Emitter<SearchFeedState> emit) async {
+    emit(SearchFeedLoadingState());
+    try {
+      final List<Articles> news =
+          await repository.getNewsBySearchQuery(event.query);
+      emit(SearchFeedLoadedState(news: news));
+    } catch (e) {
+      emit(SearchFeedErrorState(message: e.toString()));
     }
   }
 }


### PR DESCRIPTION
## Summary
- migrate `NewsFeedBloc` and `SearchFeedBloc` to the modern Bloc API
- remove deprecated `mapEventToState` and `initialState`
- add explicit `on<Event>` handlers with `emit`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685facd58a148329ab4a6b9e7f7360e6