### PR TITLE
Update intl dependency

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -391,7 +391,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.0"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  intl: ^0.18.1
+  intl: ^0.20.2
   dio: ^5.3.3
   cupertino_icons: ^1.0.2
   flutter_feather_icons: ^2.0.0


### PR DESCRIPTION
## Summary
- bump `intl` package to `^0.20.2`
- update `pubspec.lock` for the new `intl` version

## Testing
- `flutter pub get` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb14deef08329a061e533a259972f