### PR TITLE
Fix news API base URL

### DIFF
--- a/lib/app/dio/dio.dart
+++ b/lib/app/dio/dio.dart
@@ -18,7 +18,7 @@ class GetDio {
           options.receiveTimeout = 90000;
           options.sendTimeout = 90000;
           options.followRedirects = true;
-          options.baseUrl = "http://newsapi.org/v2/";
+          options.baseUrl = "https://newsapi.org/v2/";
           options.headers["X-Api-Key"] = "${Global.apikey}";
 
           return options;


### PR DESCRIPTION
## Summary
- update Dio base URL to use `https` instead of `http`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb171b18c83298d1f182ca70d6b25