### PR TITLE
Remove unused parameter from dispose

### DIFF
--- a/lib/controller/feed_controller.dart
+++ b/lib/controller/feed_controller.dart
@@ -44,7 +44,7 @@ class FeedController {
     return index;
   }
 
-  static void dispose(String stream) {
+  static void dispose() {
     _currentArticleIndex.close();
     _currentPage.close();
   }


### PR DESCRIPTION
## Summary
- remove unused `stream` parameter from `FeedController.dispose`

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fb1800f048329b9df812326b164ad