### PR TITLE
Fix provider initialization

### DIFF
--- a/lib/controller/provider.dart
+++ b/lib/controller/provider.dart
@@ -6,7 +6,7 @@ import 'package:inshort_clone/view/app_base/app_base.dart';
 import 'package:inshort_clone/view/discover_screen/discover.dart';
 
 class FeedProvider extends ChangeNotifier {
-  String _appBarTitle;
+  String? _appBarTitle;
   int _activeCategory = 1;
   bool _hasDataLoaded = false;
   bool _searchAppBarVisible = true;
@@ -14,8 +14,8 @@ class FeedProvider extends ChangeNotifier {
   bool _watermarkVisible = false;
   bool _feedBottomActionbarVisible = false;
   int _currentArticleIndex = 0;
-  PageController _feedPageController;
-  PageController _screenController;
+  late PageController _feedPageController;
+  late PageController _screenController;
   List<Widget> _baseScreen = [
     DiscoverScreen(),
     BuildNewsScreen(),
@@ -30,7 +30,7 @@ class FeedProvider extends ChangeNotifier {
 
   int get getActiveCategory => this._activeCategory;
 
-  String get getAppBarTitle => this._appBarTitle;
+  String? get getAppBarTitle => _appBarTitle;
 
   bool get getSearchAppBarVisible => this._searchAppBarVisible;
 


### PR DESCRIPTION
## Summary
- mark provider fields as nullable or late for safer initialization
- update getters for the changed fields

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb682d2d0832990e36e79bd8d2612