### PR TITLE
Add flutter lints analysis

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    # Additional lints can be added here
+


### PR DESCRIPTION
## Summary
- add `analysis_options.yaml` using `flutter_lints`

## Testing
- `flutter analyze` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb685f1248329b947e6bbf283708a