### PR TITLE
Fix search screen imports

### DIFF
--- a/lib/view/search_screen/search.dart
+++ b/lib/view/search_screen/search.dart
@@ -7,9 +7,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 // Project imports:
 import 'package:inshort_clone/application_localization.dart';
-import 'package:inshort_clone/bloc/serach_feed/search_feed_bloc.dart';
-import 'package:inshort_clone/bloc/serach_feed/search_feed_event.dart';
-import 'package:inshort_clone/bloc/serach_feed/search_feed_state.dart';
+import 'package:inshort_clone/bloc/search_feed/search_feed_bloc.dart';
+import 'package:inshort_clone/bloc/search_feed/search_feed_event.dart';
+import 'package:inshort_clone/bloc/search_feed/search_feed_state.dart';
 import 'package:inshort_clone/style/text_style.dart';
 import 'package:inshort_clone/view/search_screen/widget/search_news_card.dart';
 


### PR DESCRIPTION
## Summary
- correct imports for SearchFeedBloc files

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc53126bc83299dc4dbd5ddca8146