### PR TITLE
Use required named params

### DIFF
--- a/lib/common/widgets/news_card/bottom_action_bar.dart
+++ b/lib/common/widgets/news_card/bottom_action_bar.dart
@@ -22,9 +22,9 @@ class BottomActionBar extends StatelessWidget {
   final Articles articles;
 
   const BottomActionBar({
-    Key key,
-    this.containerKey,
-    this.articles,
+    Key? key,
+    required this.containerKey,
+    required this.articles,
   }) : super(key: key);
 
   @override

--- a/lib/common/widgets/news_card/bottom_bar.dart
+++ b/lib/common/widgets/news_card/bottom_bar.dart
@@ -18,7 +18,10 @@ import '../../../application_localization.dart';
 class BottomBar extends StatelessWidget {
   final Articles articles;
 
-  const BottomBar({Key key, this.articles}) : super(key: key);
+  const BottomBar({
+    Key? key,
+    required this.articles,
+  }) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return GestureDetector(

--- a/lib/common/widgets/news_card/news_card.dart
+++ b/lib/common/widgets/news_card/news_card.dart
@@ -30,7 +30,11 @@ class NewsCard extends StatelessWidget {
   final Articles article;
   final bool isFromSearch;
 
-  const NewsCard({Key key, this.article, this.isFromSearch}) : super(key: key);
+  const NewsCard({
+    Key? key,
+    required this.article,
+    required this.isFromSearch,
+  }) : super(key: key);
 
   @override
   build(BuildContext context) {

--- a/lib/model/news_model.dart
+++ b/lib/model/news_model.dart
@@ -8,7 +8,11 @@ class NewsModel {
   int totalResults;
   List<Articles> articles;
 
-  NewsModel({this.status, this.totalResults, this.articles});
+  NewsModel({
+    required this.status,
+    required this.totalResults,
+    required this.articles,
+  });
 
   NewsModel.fromJson(Map<String, dynamic> json) {
     status = json['status'];
@@ -51,15 +55,16 @@ class Articles {
   @HiveField(7)
   String content;
 
-  Articles(
-      {this.sourceName,
-      this.author,
-      this.title,
-      this.description,
-      this.url,
-      this.urlToImage,
-      this.publishedAt,
-      this.content});
+  Articles({
+    required this.sourceName,
+    required this.author,
+    required this.title,
+    required this.description,
+    required this.url,
+    required this.urlToImage,
+    required this.publishedAt,
+    required this.content,
+  });
 
   Articles.fromJson(Map<String, dynamic> json) {
     sourceName = json['source'] != null
@@ -94,7 +99,10 @@ class Source {
   String id;
   String name;
 
-  Source({this.id, this.name});
+  Source({
+    required this.id,
+    required this.name,
+  });
 
   Source.fromJson(Map<String, dynamic> json) {
     id = json['id'];

--- a/lib/view/discover_screen/widgets/category_card.dart
+++ b/lib/view/discover_screen/widgets/category_card.dart
@@ -13,9 +13,13 @@ class CategoryCard extends StatelessWidget {
   final Function onTap;
   final bool active;
 
-  const CategoryCard(
-      {Key key, this.icon, this.title, this.onTap, this.active = false})
-      : super(key: key);
+  const CategoryCard({
+    Key? key,
+    required this.icon,
+    required this.title,
+    required this.onTap,
+    this.active = false,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/view/discover_screen/widgets/topics_card.dart
+++ b/lib/view/discover_screen/widgets/topics_card.dart
@@ -12,8 +12,12 @@ class TopicCard extends StatelessWidget {
   final String title;
   final Function onTap;
 
-  const TopicCard({Key key, this.icon, this.title, this.onTap})
-      : super(key: key);
+  const TopicCard({
+    Key? key,
+    required this.icon,
+    required this.title,
+    required this.onTap,
+  }) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return GestureDetector(

--- a/lib/view/search_screen/widget/search_news_card.dart
+++ b/lib/view/search_screen/widget/search_news_card.dart
@@ -14,7 +14,11 @@ class SearchNewsCard extends StatelessWidget {
   final List<Articles> articles;
   final int index;
 
-  const SearchNewsCard({Key key, this.articles, this.index}) : super(key: key);
+  const SearchNewsCard({
+    Key? key,
+    required this.articles,
+    required this.index,
+  }) : super(key: key);
   @override
   Widget build(BuildContext context) {
     var article = articles[index];


### PR DESCRIPTION
## Summary
- require fields in news model constructors
- mark widget params required for consistency

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc9dc784c832997a281006019dbd8