### PR TITLE
Fix uninitialized localization map

### DIFF
--- a/lib/application_localization.dart
+++ b/lib/application_localization.dart
@@ -17,7 +17,7 @@ class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  Map<String, String> _localizedStrings;
+  late Map<String, String> _localizedStrings;
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();


### PR DESCRIPTION
## Summary
- mark `_localizedStrings` as `late`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcd2a65e08329b539d2fd1e972022