### PR TITLE
Fix untyped stream controllers

### DIFF
--- a/lib/controller/feed_controller.dart
+++ b/lib/controller/feed_controller.dart
@@ -2,8 +2,8 @@
 import 'dart:async';
 
 class FeedController {
-  static StreamController _currentPage = StreamController<int>.broadcast();
-  static StreamController _currentArticleIndex =
+  static StreamController<int> _currentPage = StreamController<int>.broadcast();
+  static StreamController<int> _currentArticleIndex =
       StreamController<int>.broadcast();
 
   static Stream<int> get _currentPageStream => _currentPage.stream;


### PR DESCRIPTION
## Summary
- specify the generic type for `_currentPage` and `_currentArticleIndex`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fcd2c0b60832993414e5cf20a4748