### PR TITLE
Fix WebScreen null-safety issue

### DIFF
--- a/lib/view/web_screen/web.dart
+++ b/lib/view/web_screen/web.dart
@@ -16,7 +16,7 @@ import 'package:inshort_clone/controller/provider.dart';
 class WebScreen extends StatefulWidget {
   final String url;
   final bool isFromBottom;
-  final PageController pageController;
+  final PageController? pageController;
 
   const WebScreen({
     required this.url,
@@ -50,7 +50,7 @@ class _WebScreenState extends State<WebScreen> {
               widget.isFromBottom
                   ? Navigator.pop(context)
                   : widget.pageController != null
-                      ? widget.pageController.jumpToPage(0)
+                      ? widget.pageController!.jumpToPage(0)
                       : FeedController.addCurrentPage(1);
             }),
         actions: <Widget>[


### PR DESCRIPTION
## Summary
- make `WebScreen.pageController` nullable
- guard `jumpToPage` call with `!`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fce92bc10832999bfa9d4b316bf7a