### PR TITLE
Fix nullable source name issue

### DIFF
--- a/lib/common/widgets/news_card/news_card.dart
+++ b/lib/common/widgets/news_card/news_card.dart
@@ -177,7 +177,7 @@ class NewsCard extends StatelessWidget {
                                     height: 16,
                                   ),
                                   Text(
-                                    "${AppLocalizations.of(context).translate("swipe_message")} ${article.sourceName} / ${DateFormat("MMMM d").format(
+                                    "${AppLocalizations.of(context).translate('swipe_message')} ${article.sourceName ?? ''} / ${DateFormat('MMMM d').format(
                                       DateTime.parse(article.publishedAt),
                                     )}",
                                     style: AppTextStyle.newsFooter,

--- a/lib/model/news_model.dart
+++ b/lib/model/news_model.dart
@@ -39,7 +39,7 @@ class NewsModel {
 @HiveType(typeId: 101)
 class Articles {
   @HiveField(0)
-  String sourceName;
+  String? sourceName;
   @HiveField(1)
   String author;
   @HiveField(2)
@@ -56,7 +56,7 @@ class Articles {
   String content;
 
   Articles({
-    required this.sourceName,
+    this.sourceName,
     required this.author,
     required this.title,
     required this.description,

--- a/lib/model/news_model.g.dart
+++ b/lib/model/news_model.g.dart
@@ -14,7 +14,7 @@ class ArticlesAdapter extends TypeAdapter<Articles> {
       for (var i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return Articles(
-      sourceName: fields[0] as String,
+      sourceName: fields[0] as String?,
       author: fields[1] as String,
       title: fields[2] as String,
       description: fields[3] as String,


### PR DESCRIPTION
## Summary
- mark `Articles.sourceName` as nullable and adjust constructor
- handle nullable `sourceName` in Hive adapter
- avoid `null` source name text in `news_card` widget

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd12b1df88329b3914056acff6414