### PR TITLE
Fix null locale check and snapshot

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -55,10 +55,12 @@ class App extends StatelessWidget {
           ],
           localeResolutionCallback: (locale, supportedLocales) {
             // Check if the current device locale is supported
-            for (var supportedLocale in supportedLocales) {
-              if (supportedLocale.languageCode == locale.languageCode &&
-                  supportedLocale.countryCode == locale.countryCode) {
-                return supportedLocale;
+            if (locale != null) {
+              for (var supportedLocale in supportedLocales) {
+                if (supportedLocale.languageCode == locale.languageCode &&
+                    supportedLocale.countryCode == locale.countryCode) {
+                  return supportedLocale;
+                }
               }
             }
 

--- a/lib/view/web_screen/web.dart
+++ b/lib/view/web_screen/web.dart
@@ -60,10 +60,10 @@ class _WebScreenState extends State<WebScreen> {
                   AsyncSnapshot<WebViewController> snapshot) {
                 final bool webViewReady =
                     snapshot.connectionState == ConnectionState.done;
-                final WebViewController controller = snapshot.data;
+                final controller = snapshot.data;
                 return IconButton(
                   icon: const Icon(Icons.replay),
-                  onPressed: !webViewReady
+                  onPressed: !webViewReady || controller == null
                       ? null
                       : () {
                           setState(() {


### PR DESCRIPTION
## Summary
- handle `Locale?` in `localeResolutionCallback`
- guard against null controller in `WebScreen` refresh logic

## Testing
- `dart format lib/app/app.dart lib/view/web_screen/web.dart` *(fails: `dart: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685fd2b6e90c83299a81d7e607ed8b76