### PR TITLE
Fix theme Brightness parameter

### DIFF
--- a/lib/style/theme.dart
+++ b/lib/style/theme.dart
@@ -1,5 +1,6 @@
 // Flutter imports:
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 // Project imports:
 import 'package:inshort_clone/style/colors.dart';
@@ -15,7 +16,7 @@ final ThemeData kDarkThemeData = ThemeData(
   accentColor: AppColor.accent,
   appBarTheme: AppBarTheme(
     color: Color(0xff333333),
-    brightness: Brightness.dark,
+    systemOverlayStyle: SystemUiOverlayStyle.light,
     iconTheme: IconThemeData(
       color: AppColor.accent,
     ),
@@ -38,7 +39,7 @@ final ThemeData kLightThemeData = ThemeData(
   ),
   appBarTheme: AppBarTheme(
     color: Colors.white,
-    brightness: Brightness.light,
+    systemOverlayStyle: SystemUiOverlayStyle.dark,
     iconTheme: IconThemeData(
       color: AppColor.accent,
     ),


### PR DESCRIPTION
## Summary
- fix `AppBarTheme` usage with `systemOverlayStyle`
- import `flutter/services.dart` to access `SystemUiOverlayStyle`

## Testing
- `flutter` was not available in the environment, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_685fd745d6348329b5ef43cd49f13169