### PR TITLE
Fix outdated parameters for Flutter 5

### DIFF
--- a/lib/app/dio/dio.dart
+++ b/lib/app/dio/dio.dart
@@ -13,27 +13,27 @@ class GetDio {
     Dio dio = Dio();
     dio.interceptors.add(
       InterceptorsWrapper(
-        onRequest: (RequestOptions options) async {
-          options.connectTimeout = 90000;
-          options.receiveTimeout = 90000;
-          options.sendTimeout = 90000;
+        onRequest: (options, handler) async {
+          options.connectTimeout = const Duration(milliseconds: 90000);
+          options.receiveTimeout = const Duration(milliseconds: 90000);
+          options.sendTimeout = const Duration(milliseconds: 90000);
           options.followRedirects = true;
           options.baseUrl = "https://newsapi.org/v2/";
           options.headers["X-Api-Key"] = "${Global.apikey}";
 
-          return options;
+          handler.next(options);
         },
-        onResponse: (Response response) async {
-          return response;
+        onResponse: (response, handler) async {
+          handler.next(response);
         },
-        onError: (DioError dioError) async {
-          if (dioError.type == DioErrorType.DEFAULT) {
-            if (dioError.message.contains('SocketException')) {
+        onError: (DioException dioError, handler) async {
+          if (dioError.type == DioExceptionType.unknown) {
+            if (dioError.message?.contains('SocketException') ?? false) {
               logMessage('no internet');
             }
           }
 
-          return dioError.response; //continue
+          handler.next(dioError); //continue
         },
       ),
     );

--- a/lib/style/theme.dart
+++ b/lib/style/theme.dart
@@ -29,7 +29,6 @@ final ThemeData kDarkThemeData = ThemeData(
 
 final ThemeData kLightThemeData = ThemeData(
   canvasColor: AppColor.background,
-  errorColor: AppColor.error,
   colorScheme: ColorScheme.light(
     primary: AppColor.accent,
     secondary: AppColor.accent,


### PR DESCRIPTION
## Summary
- remove obsolete `errorColor` parameter from `kLightThemeData`
- update Dio interceptor callbacks for Dio 5.x API

## Testing
- `dart` and `flutter` were unavailable, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_685fd9d141688329a8a7c38f129ec68b