### PR TITLE
Fix localization of method null safety

### DIFF
--- a/lib/application_localization.dart
+++ b/lib/application_localization.dart
@@ -14,7 +14,7 @@ class AppLocalizations {
   // Helper method to keep the code in the widgets concise
   // Localizations are accessed using an InheritedWidget "of" syntax
   static AppLocalizations of(BuildContext context) {
-    return Localizations.of<AppLocalizations>(context, AppLocalizations);
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
   }
 
   late Map<String, String> _localizedStrings;


### PR DESCRIPTION
## Summary
- fix null safety issue in `AppLocalizations.of` by asserting a non-null value

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fdb6b728c832984fe20521e3c9a14