### PR TITLE
Fix null safety for app bar title

### DIFF
--- a/lib/common/widgets/appbar.dart
+++ b/lib/common/widgets/appbar.dart
@@ -69,12 +69,9 @@ class CustomAppBar extends StatelessWidget {
                     Expanded(
                       child: Text(
                         index == 1
-                            ? value.getAppBarTitle != null
-                                ? value.getAppBarTitle
-                                : AppLocalizations.of(context)
-                                    .translate("my_feed")
-                            : AppLocalizations.of(context)
-                                .translate("discover"),
+                            ? value.getAppBarTitle ??
+                                AppLocalizations.of(context).translate("my_feed")
+                            : AppLocalizations.of(context).translate("discover"),
                         style: AppTextStyle.appBarTitle.copyWith(
                           fontWeight: FontWeight.w600,
                           fontSize: 16,
@@ -90,9 +87,8 @@ class CustomAppBar extends StatelessWidget {
                           children: <Widget>[
                             index != 1
                                 ? Text(
-                                    value.getAppBarTitle != null
-                                        ? value.getAppBarTitle
-                                        : AppLocalizations.of(context)
+                                    value.getAppBarTitle ??
+                                        AppLocalizations.of(context)
                                             .translate("my_feed"),
                                     style: AppTextStyle.appBarTitle,
                                     overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
## Summary
- use `??` to default to translation when appBarTitle is null

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fdd378dfc8329a3a6160fc46f84a0