### PR TITLE
Fix language dropdown type mismatch

### DIFF
--- a/lib/view/settings_screen/settings.dart
+++ b/lib/view/settings_screen/settings.dart
@@ -52,7 +52,7 @@ class SettingsScreen extends StatelessWidget {
               leading: Icon(FontAwesomeIcons.language),
               title: Text(AppLocalizations.of(context).translate('language')),
               onTap: () {},
-              trailing: DropdownButton(
+              trailing: DropdownButton<String>(
                   underline: Container(),
                   value: settingsProvider.activeLanguge,
                   items: Global.lang.map((String value) {
@@ -61,8 +61,10 @@ class SettingsScreen extends StatelessWidget {
                       child: Text(value),
                     );
                   }).toList(),
-                  onChanged: (v) {
-                    settingsProvider.setLang(v);
+                  onChanged: (String? v) {
+                    if (v != null) {
+                      settingsProvider.setLang(v);
+                    }
                   }),
             )
           ],


### PR DESCRIPTION
## Summary
- specify generic type for `DropdownButton`
- handle null values in settings screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe0452a788329988337a3c40ef593