### PR TITLE
Fix onTap type for BottomActionBar

### DIFF
--- a/lib/common/widgets/news_card/bottom_action_bar.dart
+++ b/lib/common/widgets/news_card/bottom_action_bar.dart
@@ -67,7 +67,7 @@ class BottomActionBar extends StatelessWidget {
   Widget actionButton({
     required String title,
     required IconData icon,
-    required Function onTap,
+    required VoidCallback onTap,
   }) {
     return InkWell(
       onTap: onTap,


### PR DESCRIPTION
## Summary
- change `Function` parameter to `VoidCallback` in `BottomActionBar`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe12d482483298d2bb9bcc064032b