### PR TITLE
Fix ByteData nullability in share_service

### DIFF
--- a/lib/services/news/share_service.dart
+++ b/lib/services/news/share_service.dart
@@ -23,8 +23,9 @@ void convertWidgetToImageAndShare(BuildContext context, containerKey) async {
       containerKey.currentContext.findRenderObject() as RenderRepaintBoundary;
   final ui.Image boxImage =
       await renderRepaintBoundary.toImage(pixelRatio: 1);
-  final ByteData byteData =
+  final ByteData? byteData =
       await boxImage.toByteData(format: ui.ImageByteFormat.png);
+  if (byteData == null) return;
   final Uint8List uInt8List = byteData.buffer.asUint8List();
 
   try {


### PR DESCRIPTION
## Summary
- handle nullable `ByteData` from `ui.Image.toByteData`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe2be79648329a917a935be31cce6