### PR TITLE
Initialize AppBase page controller

### DIFF
--- a/lib/view/app_base/app_base.dart
+++ b/lib/view/app_base/app_base.dart
@@ -26,8 +26,8 @@ class AppBase extends StatefulWidget {
 
 class _AppBaseState extends State<AppBase> with AutomaticKeepAliveClientMixin {
   int currentPage = 1;
-  PageController _pageController;
-  FeedProvider provider;
+  late PageController _pageController;
+  late FeedProvider provider;
 
   @override
   void initState() {


### PR DESCRIPTION
## Summary
- fix null safety error in AppBase by marking controller and provider as `late`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fe54c782c832999307042dbe934a4