### PR TITLE
Fix null safety error in Dio helper

### DIFF
--- a/lib/app/dio/dio.dart
+++ b/lib/app/dio/dio.dart
@@ -6,7 +6,6 @@ import 'package:inshort_clone/common/utils/logger.dart';
 import 'package:inshort_clone/global/global.dart';
 
 class GetDio {
-  bool loggedIn;
   GetDio._();
 
   static Dio getDio() {


### PR DESCRIPTION
## Summary
- remove unused `loggedIn` field from `GetDio`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe64c3e4083298ff57910b6028338