### PR TITLE
Fix null language crash

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,7 +27,7 @@ void main() async {
   final _isDarkModeOn = await Hive.box('settingsBox').get('isDarkModeOn');
   SettingsProvider().darkTheme(_isDarkModeOn ?? false);
 
-  final _lang = await Hive.box('settingsBox').get('activeLang');
+  final _lang = await Hive.box('settingsBox').get('activeLang') ?? "English";
   SettingsProvider().setLang(_lang);
 
   SystemChrome.setSystemUIOverlayStyle(


### PR DESCRIPTION
## Summary
- set a default language when `activeLang` key is missing to avoid `null` crash

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe95d92408329890895f8f2a6ad13