### PR TITLE
Filter news by date

### DIFF
--- a/lib/services/news/news_service.dart
+++ b/lib/services/news/news_service.dart
@@ -13,6 +13,8 @@ import 'package:inshort_clone/controller/provider.dart';
 import 'package:inshort_clone/model/news_model.dart';
 import 'package:inshort_clone/services/news/offline_service.dart';
 
+const String _fromDate = '2025-06-20';
+
 abstract class NewsFeedRepository {
   Future<List<Articles>> getNewsByTopic(String topic);
 
@@ -27,9 +29,23 @@ class NewsFeedRepositoryImpl implements NewsFeedRepository {
   final BuildContext context;
   NewsFeedRepositoryImpl(this.context);
 
+  List<Articles> _filterArticles(List<Articles> articles) {
+    final DateTime cutoff = DateTime.parse(_fromDate);
+    return articles
+        .where((article) {
+          try {
+            final DateTime published = DateTime.parse(article.publishedAt);
+            return !published.isBefore(cutoff);
+          } catch (_) {
+            return false;
+          }
+        })
+        .toList();
+  }
+
   @override
   Future<List<Articles>> getNewsByTopic(String topic) async {
-    final String url = "everything?q=$topic";
+    final String url = "everything?q=$topic&from=$_fromDate";
     final provider = Provider.of<FeedProvider>(context, listen: false);
 
     provider.setDataLoaded(false);
@@ -38,7 +54,8 @@ class NewsFeedRepositoryImpl implements NewsFeedRepository {
 
     Response response = await GetDio.getDio().get(url);
     if (response.statusCode == 200) {
-      List<Articles> articles = NewsModel.fromJson(response.data).articles;
+      List<Articles> articles =
+          _filterArticles(NewsModel.fromJson(response.data).articles);
 
       provider.setDataLoaded(true);
       addArticlesToUnreads(articles);
@@ -60,7 +77,8 @@ class NewsFeedRepositoryImpl implements NewsFeedRepository {
 
     Response response = await GetDio.getDio().get(url);
     if (response.statusCode == 200) {
-      List<Articles> articles = NewsModel.fromJson(response.data).articles;
+      List<Articles> articles =
+          _filterArticles(NewsModel.fromJson(response.data).articles);
 
       provider.setDataLoaded(true);
       addArticlesToUnreads(articles);
@@ -78,11 +96,12 @@ class NewsFeedRepositoryImpl implements NewsFeedRepository {
 
     provider.setDataLoaded(false);
 
-    final String url = "everything?q=$query";
+    final String url = "everything?q=$query&from=$_fromDate";
 
     Response response = await GetDio.getDio().get(url);
     if (response.statusCode == 200) {
-      List<Articles> articles = NewsModel.fromJson(response.data).articles;
+      List<Articles> articles =
+          _filterArticles(NewsModel.fromJson(response.data).articles);
 
       addArticlesToUnreads(articles);
       provider.setDataLoaded(true);
@@ -112,7 +131,7 @@ class NewsFeedRepositoryImpl implements NewsFeedRepository {
       }
       provider.setDataLoaded(true);
 
-      return articles;
+      return _filterArticles(articles);
     } else {
       provider.setDataLoaded(true);
       List<Articles> articles = [];


### PR DESCRIPTION
## Summary
- ensure every news fetch only keeps articles from after June 20, 2025
- add `_filterArticles` helper to remove older entries
- apply date filter to topic, category, search and local-storage results

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603a6ddb588329bdfba7655ac1fcb6