### PR TITLE
Fix import order in discover screen

### DIFF
--- a/lib/view/discover_screen/discover.dart
+++ b/lib/view/discover_screen/discover.dart
@@ -14,19 +14,6 @@ import 'package:inshort_clone/controller/provider.dart';
 import 'package:inshort_clone/view/discover_screen/widgets/category_card.dart';
 import 'package:inshort_clone/view/discover_screen/widgets/headline.dart';
 import 'package:inshort_clone/view/discover_screen/widgets/topics_card.dart';
-
-class _TopicData {
-  final String key;
-  final String icon;
-  final bool isCategory;
-  final String value;
-
-  const _TopicData(
-      {required this.key,
-      required this.icon,
-      required this.isCategory,
-      required this.value});
-}
 import 'widgets/app_bar.dart';
 
 class _TopicData {


### PR DESCRIPTION
## Summary
- clean up `discover.dart`
- ensure imports come before declarations

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_68604dd5fc088329a63215c6db1fa743